### PR TITLE
Open code editor by default for JodelWebClient (instead of the deisgner)

### DIFF
--- a/JodelAPI/JodelAPI/Internal/JodelWebClient.cs
+++ b/JodelAPI/JodelAPI/Internal/JodelWebClient.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 
 namespace JodelAPI.Internal
 {
+    [System.ComponentModel.DesignerCategory("Code")]
     internal class JodelWebClient : WebClient
     {
         protected override WebRequest GetWebRequest(Uri address)

--- a/JodelAPI/JodelAPI/JodelAPI.csproj
+++ b/JodelAPI/JodelAPI/JodelAPI.csproj
@@ -51,9 +51,7 @@
     <Compile Include="Internal\ApiCall.cs" />
     <Compile Include="Internal\Constants.cs" />
     <Compile Include="Internal\Helpers.cs" />
-    <Compile Include="Internal\JodelWebClient.cs">
-      <SubType>Component</SubType>
-    </Compile>
+    <Compile Include="Internal\JodelWebClient.cs" />
     <Compile Include="Internal\Links.cs" />
     <Compile Include="Jodel.cs" />
     <Compile Include="JodelApp.cs" />


### PR DESCRIPTION
Currently, the designer is opened by visual studio when double-clicking on JodelWebClient.cs. This is due to the class inheriting from System.Net.WebClient. With this pull request, the code editor will be opened per default.